### PR TITLE
Ampersands in download URL

### DIFF
--- a/mozilla/firefoxesr.download.recipe
+++ b/mozilla/firefoxesr.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>FirefoxESR</string>
 		<key>DOWNLOAD_URL</key>
-    <string>https://download.mozilla.org/?product=firefox-esr-latest&os=osx&lang=en-US</string>
+    <string>https://download.mozilla.org/?product=firefox-esr-latest&amp;os=osx&amp;lang=en-US</string>
 	</dict>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.download.firefox-rc-en_US</string>


### PR DESCRIPTION
Fixes .plist error:
```
Error Domain=NSCocoaErrorDomain Code=3840 "Encountered unknown ampersand-escape sequence at line 14" UserInfo={NSDebugDescription=Encountered unknown ampersand-escape sequence at line 14, kCFPropertyListOldStyleParsingError=Error Domain=NSCocoaErrorDomain Code=3840 "Malformed data byte group at line 1; invalid hex" UserInfo={NSDebugDescription=Malformed data byte group at line 1; invalid hex}}
```