### PR TITLE
Ampersand HTML

### DIFF
--- a/mozilla/firefoxesr.pkg.recipe
+++ b/mozilla/firefoxesr.pkg.recipe
@@ -9,7 +9,7 @@
        <key>NAME</key>
         <string>FirefoxESR</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://download.mozilla.org/?product=firefox-esr-latest&os=osx&lang=en-US</string>
+        <string>https://download.mozilla.org/?product=firefox-esr-latest&amp;os=osx&amp;lang=en-US</string>
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.autopkg.pkg.Firefox_EN</string>


### PR DESCRIPTION
Fixes this .plist error:
```
Error Domain=NSCocoaErrorDomain Code=3840 "Encountered unknown ampersand-escape sequence at line 12" UserInfo={NSDebugDescription=Encountered unknown ampersand-escape sequence at line 12, kCFPropertyListOldStyleParsingError=Error Domain=NSCocoaErrorDomain Code=3840 "Malformed data byte group at line 1; invalid hex" UserInfo={NSDebugDescription=Malformed data byte group at line 1; invalid hex}}
```