### PR TITLE
Deprecated FileWave Lightning recipes

### DIFF
--- a/filewave-lightning/filewavelightning.download.recipe
+++ b/filewave-lightning/filewavelightning.download.recipe
@@ -17,21 +17,24 @@
     <string>0.1.0</string>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
-                <key>filename</key>
-                <string>%NAME%.dmg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is now non-functional. Please remove it from your list of recipes.</string>
+			</dict>
+			<key>Processor</key>
+			<string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>predicate</key>
+				<string>TRUEPREDICATE</string>
+			</dict>
+			<key>Processor</key>
+			<string>StopProcessingIf</string>
+		</dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Lightning is now in the "archive" section of the FileWave website, and doesn't look like any further updates will be released. Also, there's a hard-coded version in the DOWNLOAD_URL of this recipe.