### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/filewave-lightning/filewavelightning.download.recipe
+++ b/filewave-lightning/filewavelightning.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>FileWaveLightning</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://fwdl.filewave.com/lightning/FileWave_Lightning-1.8.7.dmg</string>
+        <string>https://fwdl.filewave.com/lightning/FileWave_Lightning-1.8.7.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.1.0</string>

--- a/filewave-lightning/filewavelightning.filewave.recipe
+++ b/filewave-lightning/filewavelightning.filewave.recipe
@@ -13,7 +13,7 @@
 		<key>FW_FILESET_GROUP</key>
 		<string>Autpkg</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>http://fwdl.filewave.com/lightning/FileWave_Lightning-1.8.6.dmg</string>
+		<string>https://fwdl.filewave.com/lightning/FileWave_Lightning-1.8.6.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._